### PR TITLE
Changes for VS Code CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-src"
+version = "111.22.0+1.1.1q"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +725,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -63,6 +63,9 @@ tokio = { version = "1.17.0", features = [
 tokio-stream = { version = "0.1", features = ["net"] }
 yasna = { version = "0.4.0", features = ["bit-vec", "num-bigint"] }
 
+[features]
+vendored-openssl = ["openssl", "openssl/vendored"]
+
 [dev-dependencies]
 env_logger = "0.8"
 tempdir = "0.3"

--- a/russh-keys/src/key.rs
+++ b/russh-keys/src/key.rs
@@ -429,7 +429,7 @@ fn rsa_signature(
 }
 
 /// Parse a public key from a byte slice.
-pub fn parse_public_key(p: &[u8], _prefer_hash: Option<SignatureHash>) -> Result<PublicKey, Error> {
+pub fn parse_public_key(p: &[u8], prefer_hash: Option<SignatureHash>) -> Result<PublicKey, Error> {
     let mut pos = p.reader(0);
     let t = pos.read_string()?;
     if t == b"ssh-ed25519" {

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.34.0-beta.7"
 
 [features]
 default = ["flate2"]
+vendored-openssl = ["openssl", "openssl/vendored"]
 
 [dependencies]
 aes = "0.8"

--- a/russh/src/channels.rs
+++ b/russh/src/channels.rs
@@ -315,15 +315,13 @@ impl<Send: From<(ChannelId, ChannelMsg)>> Channel<Send> {
 
     /// Wait for data to come.
     pub async fn wait(&mut self) -> Option<ChannelMsg> {
-        loop {
-            match self.receiver.recv().await {
-                Some(ChannelMsg::WindowAdjusted { new_size }) => {
-                    self.window_size += new_size;
-                    return Some(ChannelMsg::WindowAdjusted { new_size });
-                }
-                Some(msg) => return Some(msg),
-                None => return None,
+        match self.receiver.recv().await {
+            Some(ChannelMsg::WindowAdjusted { new_size }) => {
+                self.window_size += new_size;
+                Some(ChannelMsg::WindowAdjusted { new_size })
             }
+            Some(msg) => Some(msg),
+            None => None,
         }
     }
 

--- a/russh/src/channels.rs
+++ b/russh/src/channels.rs
@@ -1,0 +1,336 @@
+use russh_cryptovec::CryptoVec;
+use tokio::sync::mpsc::{Sender, UnboundedReceiver};
+
+use crate::{ChannelId, Error, Pty, Sig};
+
+#[derive(Debug)]
+pub enum ChannelMsg {
+    Open {
+        id: ChannelId,
+        max_packet_size: u32,
+        window_size: u32,
+    },
+    Data {
+        data: CryptoVec,
+    },
+    ExtendedData {
+        data: CryptoVec,
+        ext: u32,
+    },
+    Eof,
+    /// (client only)
+    RequestPty {
+        want_reply: bool,
+        term: String,
+        col_width: u32,
+        row_height: u32,
+        pix_width: u32,
+        pix_height: u32,
+        terminal_modes: Vec<(Pty, u32)>,
+    },
+    /// (client only)
+    RequestShell {
+        want_reply: bool,
+    },
+    /// (client only)
+    Exec {
+        want_reply: bool,
+        command: String,
+    },
+    /// (client only)
+    Signal {
+        signal: Sig,
+    },
+    /// (client only)
+    RequestSubsystem {
+        want_reply: bool,
+        name: String,
+    },
+    /// (client only)
+    RequestX11 {
+        want_reply: bool,
+        single_connection: bool,
+        x11_authentication_protocol: String,
+        x11_authentication_cookie: String,
+        x11_screen_number: u32,
+    },
+    /// (client only)
+    SetEnv {
+        want_reply: bool,
+        variable_name: String,
+        variable_value: String,
+    },
+    /// (client only)
+    WindowChange {
+        col_width: u32,
+        row_height: u32,
+        pix_width: u32,
+        pix_height: u32,
+    },
+
+    /// (server only)
+    XonXoff {
+        client_can_do: bool,
+    },
+    /// (server only)
+    ExitStatus {
+        exit_status: u32,
+    },
+    /// (server only)
+    ExitSignal {
+        signal_name: Sig,
+        core_dumped: bool,
+        error_message: String,
+        lang_tag: String,
+    },
+    /// (server only)
+    WindowAdjusted {
+        new_size: u32,
+    },
+    /// (server only)
+    Success,
+    /// (server only)
+    Close,
+}
+
+pub struct Channel<Send: From<(ChannelId, ChannelMsg)>> {
+    pub(crate) id: ChannelId,
+    pub(crate) sender: Sender<Send>,
+    pub(crate) receiver: UnboundedReceiver<ChannelMsg>,
+    pub(crate) max_packet_size: u32,
+    pub(crate) window_size: u32,
+}
+
+impl<Send: From<(ChannelId, ChannelMsg)>> Channel<Send> {
+    pub fn id(&self) -> ChannelId {
+        self.id
+    }
+
+    /// Returns the min between the maximum packet size and the
+    /// remaining window size in the channel.
+    pub fn writable_packet_size(&self) -> usize {
+        self.max_packet_size.min(self.window_size) as usize
+    }
+
+    /// Request a pseudo-terminal with the given characteristics.
+    #[allow(clippy::too_many_arguments)] // length checked
+    pub async fn request_pty(
+        &mut self,
+        want_reply: bool,
+        term: &str,
+        col_width: u32,
+        row_height: u32,
+        pix_width: u32,
+        pix_height: u32,
+        terminal_modes: &[(Pty, u32)],
+    ) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::RequestPty {
+            want_reply,
+            term: term.to_string(),
+            col_width,
+            row_height,
+            pix_width,
+            pix_height,
+            terminal_modes: terminal_modes.to_vec(),
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Request a remote shell.
+    pub async fn request_shell(&mut self, want_reply: bool) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::RequestShell { want_reply })
+            .await?;
+        Ok(())
+    }
+
+    /// Execute a remote program (will be passed to a shell). This can
+    /// be used to implement scp (by calling a remote scp and
+    /// tunneling to its standard input).
+    pub async fn exec<A: Into<String>>(
+        &mut self,
+        want_reply: bool,
+        command: A,
+    ) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::Exec {
+            want_reply,
+            command: command.into(),
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Signal a remote process.
+    pub async fn signal(&mut self, signal: Sig) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::Signal { signal }).await?;
+        Ok(())
+    }
+
+    /// Request the start of a subsystem with the given name.
+    pub async fn request_subsystem<A: Into<String>>(
+        &mut self,
+        want_reply: bool,
+        name: A,
+    ) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::RequestSubsystem {
+            want_reply,
+            name: name.into(),
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Request X11 forwarding through an already opened X11
+    /// channel. See
+    /// [RFC4254](https://tools.ietf.org/html/rfc4254#section-6.3.1)
+    /// for security issues related to cookies.
+    pub async fn request_x11<A: Into<String>, B: Into<String>>(
+        &mut self,
+        want_reply: bool,
+        single_connection: bool,
+        x11_authentication_protocol: A,
+        x11_authentication_cookie: B,
+        x11_screen_number: u32,
+    ) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::RequestX11 {
+            want_reply,
+            single_connection,
+            x11_authentication_protocol: x11_authentication_protocol.into(),
+            x11_authentication_cookie: x11_authentication_cookie.into(),
+            x11_screen_number,
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Set a remote environment variable.
+    pub async fn set_env<A: Into<String>, B: Into<String>>(
+        &mut self,
+        want_reply: bool,
+        variable_name: A,
+        variable_value: B,
+    ) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::SetEnv {
+            want_reply,
+            variable_name: variable_name.into(),
+            variable_value: variable_value.into(),
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Inform the server that our window size has changed.
+    pub async fn window_change(
+        &mut self,
+        col_width: u32,
+        row_height: u32,
+        pix_width: u32,
+        pix_height: u32,
+    ) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::WindowChange {
+            col_width,
+            row_height,
+            pix_width,
+            pix_height,
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Send data to a channel.
+    pub async fn data<R: tokio::io::AsyncReadExt + std::marker::Unpin>(
+        &mut self,
+        data: R,
+    ) -> Result<(), Error> {
+        self.send_data(None, data).await
+    }
+
+    /// Send data to a channel. The number of bytes added to the
+    /// "sending pipeline" (to be processed by the event loop) is
+    /// returned.
+    pub async fn extended_data<R: tokio::io::AsyncReadExt + std::marker::Unpin>(
+        &mut self,
+        ext: u32,
+        data: R,
+    ) -> Result<(), Error> {
+        self.send_data(Some(ext), data).await
+    }
+
+    async fn send_data<R: tokio::io::AsyncReadExt + std::marker::Unpin>(
+        &mut self,
+        ext: Option<u32>,
+        mut data: R,
+    ) -> Result<(), Error> {
+        let mut total = 0;
+        loop {
+            // wait for the window to be restored.
+            while self.window_size == 0 {
+                match self.receiver.recv().await {
+                    Some(ChannelMsg::WindowAdjusted { new_size }) => {
+                        debug!("window adjusted: {:?}", new_size);
+                        self.window_size = new_size;
+                        break;
+                    }
+                    Some(msg) => {
+                        debug!("unexpected channel msg: {:?}", msg);
+                    }
+                    None => break,
+                }
+            }
+            debug!(
+                "sending data, self.window_size = {:?}, self.max_packet_size = {:?}, total = {:?}",
+                self.window_size, self.max_packet_size, total
+            );
+            let sendable = self.window_size.min(self.max_packet_size) as usize;
+            debug!("sendable {:?}", sendable);
+            let mut c = CryptoVec::new_zeroed(sendable);
+            let n = data.read(&mut c[..]).await?;
+            total += n;
+            c.resize(n);
+            self.window_size -= n as u32;
+            self.send_data_packet(ext, c).await?;
+            if n == 0 {
+                break;
+            } else if self.window_size > 0 {
+                continue;
+            }
+        }
+        Ok(())
+    }
+
+    async fn send_data_packet(&mut self, ext: Option<u32>, data: CryptoVec) -> Result<(), Error> {
+        self.send_msg(if let Some(ext) = ext {
+            ChannelMsg::ExtendedData { ext, data }
+        } else {
+            ChannelMsg::Data { data }
+        })
+        .await?;
+        Ok(())
+    }
+
+    pub async fn eof(&mut self) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::Eof).await?;
+        Ok(())
+    }
+
+    /// Wait for data to come.
+    pub async fn wait(&mut self) -> Option<ChannelMsg> {
+        loop {
+            match self.receiver.recv().await {
+                Some(ChannelMsg::WindowAdjusted { new_size }) => {
+                    self.window_size += new_size;
+                    return Some(ChannelMsg::WindowAdjusted { new_size });
+                }
+                Some(msg) => return Some(msg),
+                None => return None,
+            }
+        }
+    }
+
+    async fn send_msg(&self, msg: ChannelMsg) -> Result<(), Error> {
+        self.sender
+            .send((self.id, msg).into())
+            .await
+            .map_err(|_| Error::SendError)
+    }
+}

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -571,7 +571,7 @@ impl super::Session {
                                 .await?
                         }
                         ChannelType::Unknown { typ } => {
-                            if client.server_channel_handle_unknown(id, &typ) {
+                            if client.server_channel_handle_unknown(id, typ) {
                                 confirm();
                             } else {
                                 debug!("unknown channel type: {}", String::from_utf8_lossy(typ));

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -530,20 +530,28 @@ impl super::Session {
                             confirm();
                             client.server_channel_open_session(id, self).await?
                         }
-                        ChannelType::DirectTcpip {
-                            host_to_connect,
-                            port_to_connect,
-                            originator_address,
-                            originator_port,
-                        } => {
+                        ChannelType::DirectTcpip(d) => {
                             confirm();
                             client
                                 .server_channel_open_direct_tcpip(
                                     id,
-                                    host_to_connect,
-                                    *port_to_connect,
-                                    originator_address,
-                                    *originator_port,
+                                    &d.host_to_connect,
+                                    d.port_to_connect,
+                                    &d.originator_address,
+                                    d.originator_port,
+                                    self,
+                                )
+                                .await?
+                        }
+                        ChannelType::ForwardedTcpIp(d) => {
+                            confirm();
+                            client
+                                .server_channel_open_direct_tcpip(
+                                    id,
+                                    &d.host_to_connect,
+                                    d.port_to_connect,
+                                    &d.originator_address,
+                                    d.originator_port,
                                     self,
                                 )
                                 .await?

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -22,7 +22,7 @@ use crate::key::PubKey;
 use crate::negotiation::{Named, Select};
 use crate::parsing::{ChannelType, OpenChannelMessage};
 use crate::{auth, msg, negotiation, ChannelId, ChannelOpenFailure, Error, Sig};
-use crate::{session::*, Channel};
+use crate::{session::*, ChannelParams};
 
 thread_local! {
     static SIGNATURE_BUFFER: RefCell<CryptoVec> = RefCell::new(CryptoVec::new());
@@ -502,7 +502,7 @@ impl super::Session {
 
                 if let Some(ref mut enc) = self.common.encrypted {
                     let id = enc.new_channel_id();
-                    let channel = Channel {
+                    let channel = ChannelParams {
                         recipient_channel: msg.recipient_channel,
                         sender_channel: id,
                         recipient_window_size: msg.recipient_window_size,

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -1057,6 +1057,20 @@ pub trait Handler: Sized {
         self.finished(session)
     }
 
+    /// Called when the server opens a forwarded tcp/ip channel.
+    #[allow(unused_variables)]
+    fn server_channel_open_forwarded_tcpip(
+        self,
+        channel: ChannelId,
+        host_to_connect: &str,
+        port_to_connect: u32,
+        originator_address: &str,
+        originator_port: u32,
+        session: Session,
+    ) -> Self::FutureUnit {
+        self.finished(session)
+    }
+
     /// Called when the server opens an X11 channel.
     #[allow(unused_variables)]
     fn server_channel_open_x11(

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -28,14 +28,13 @@ use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::pin;
 
+use crate::channels::{Channel, ChannelMsg};
 use crate::key::PubKey;
 use crate::pty::Pty;
 use crate::session::*;
 use crate::ssh_read::SshRead;
 use crate::sshbuffer::*;
-use crate::{
-    auth, negotiation, ChannelId, ChannelMsg, ChannelOpenFailure, Disconnect, Limits, Sig,
-};
+use crate::{auth, negotiation, ChannelId, ChannelOpenFailure, Disconnect, Limits, Sig};
 
 mod kex;
 use crate::cipher::{self, clear, CipherPair, OpeningKey};
@@ -49,7 +48,7 @@ pub struct Session {
     common: CommonSession<Arc<Config>>,
     receiver: Receiver<Msg>,
     sender: UnboundedSender<Reply>,
-    channels: HashMap<ChannelId, UnboundedSender<OpenChannelMsg>>,
+    channels: HashMap<ChannelId, UnboundedSender<ChannelMsg>>,
     target_window_size: u32,
     pending_reads: Vec<CryptoVec>,
     pending_len: u32,
@@ -73,7 +72,7 @@ enum Reply {
 }
 
 #[derive(Debug)]
-enum Msg {
+pub enum Msg {
     Authenticate {
         user: String,
         method: auth::Method,
@@ -82,19 +81,19 @@ enum Msg {
         data: CryptoVec,
     },
     ChannelOpenSession {
-        sender: UnboundedSender<OpenChannelMsg>,
+        sender: UnboundedSender<ChannelMsg>,
     },
     ChannelOpenX11 {
         originator_address: String,
         originator_port: u32,
-        sender: UnboundedSender<OpenChannelMsg>,
+        sender: UnboundedSender<ChannelMsg>,
     },
     ChannelOpenDirectTcpIp {
         host_to_connect: String,
         port_to_connect: u32,
         originator_address: String,
         originator_port: u32,
-        sender: UnboundedSender<OpenChannelMsg>,
+        sender: UnboundedSender<ChannelMsg>,
     },
     TcpIpForward {
         want_reply: bool,
@@ -111,77 +110,13 @@ enum Msg {
         description: String,
         language_tag: String,
     },
-    Data {
-        id: ChannelId,
-        data: CryptoVec,
-    },
-    ExtendedData {
-        id: ChannelId,
-        data: CryptoVec,
-        ext: u32,
-    },
-    Eof {
-        id: ChannelId,
-    },
-    RequestPty {
-        id: ChannelId,
-        want_reply: bool,
-        term: String,
-        col_width: u32,
-        row_height: u32,
-        pix_width: u32,
-        pix_height: u32,
-        terminal_modes: Vec<(Pty, u32)>,
-    },
-    RequestShell {
-        id: ChannelId,
-        want_reply: bool,
-    },
-    Exec {
-        id: ChannelId,
-        want_reply: bool,
-        command: String,
-    },
-    Signal {
-        id: ChannelId,
-        signal: Sig,
-    },
-    RequestSubsystem {
-        id: ChannelId,
-        want_reply: bool,
-        name: String,
-    },
-    RequestX11 {
-        id: ChannelId,
-        want_reply: bool,
-        single_connection: bool,
-        x11_authentication_protocol: String,
-        x11_authentication_cookie: String,
-        x11_screen_number: u32,
-    },
-    SetEnv {
-        id: ChannelId,
-        want_reply: bool,
-        variable_name: String,
-        variable_value: String,
-    },
-    WindowChange {
-        id: ChannelId,
-        col_width: u32,
-        row_height: u32,
-        pix_width: u32,
-        pix_height: u32,
-    },
+    Channel(ChannelId, ChannelMsg),
 }
 
-#[derive(Debug)]
-enum OpenChannelMsg {
-    Open {
-        id: ChannelId,
-        max_packet_size: u32,
-        window_size: u32,
-    },
-    Msg(ChannelMsg),
+impl From<(ChannelId, ChannelMsg)> for Msg {
+    fn from((id, msg): (ChannelId, ChannelMsg)) -> Self {
+        Msg::Channel(id, msg)
+    }
 }
 
 /// Handle to a session, used to send messages to a client outside of
@@ -196,19 +131,6 @@ impl<H: Handler> Drop for Handle<H> {
     fn drop(&mut self) {
         debug!("drop handle")
     }
-}
-
-#[derive(Clone)]
-pub struct ChannelSender {
-    sender: Sender<Msg>,
-    id: ChannelId,
-}
-
-pub struct Channel {
-    sender: ChannelSender,
-    receiver: UnboundedReceiver<OpenChannelMsg>,
-    max_packet_size: u32,
-    window_size: u32,
 }
 
 impl<H: Handler> Handle<H> {
@@ -325,20 +247,18 @@ impl<H: Handler> Handle<H> {
 
     async fn wait_channel_confirmation(
         &self,
-        mut receiver: UnboundedReceiver<OpenChannelMsg>,
-    ) -> Result<Channel, Error> {
+        mut receiver: UnboundedReceiver<ChannelMsg>,
+    ) -> Result<Channel<Msg>, Error> {
         loop {
             match receiver.recv().await {
-                Some(OpenChannelMsg::Open {
+                Some(ChannelMsg::Open {
                     id,
                     max_packet_size,
                     window_size,
                 }) => {
                     return Ok(Channel {
-                        sender: ChannelSender {
-                            sender: self.sender.clone(),
-                            id,
-                        },
+                        id,
+                        sender: self.sender.clone(),
                         receiver,
                         max_packet_size,
                         window_size,
@@ -359,7 +279,7 @@ impl<H: Handler> Handle<H> {
     /// connection is authenticated, but the channel only becomes
     /// usable when it's confirmed by the server, as indicated by the
     /// `confirmed` field of the corresponding `Channel`.
-    pub async fn channel_open_session(&mut self) -> Result<Channel, Error> {
+    pub async fn channel_open_session(&mut self) -> Result<Channel<Msg>, Error> {
         let (sender, receiver) = unbounded_channel();
         self.sender
             .send(Msg::ChannelOpenSession { sender })
@@ -373,7 +293,7 @@ impl<H: Handler> Handle<H> {
         &mut self,
         originator_address: A,
         originator_port: u32,
-    ) -> Result<Channel, Error> {
+    ) -> Result<Channel<Msg>, Error> {
         let (sender, receiver) = unbounded_channel();
         self.sender
             .send(Msg::ChannelOpenX11 {
@@ -397,7 +317,7 @@ impl<H: Handler> Handle<H> {
         port_to_connect: u32,
         originator_address: B,
         originator_port: u32,
-    ) -> Result<Channel, Error> {
+    ) -> Result<Channel<Msg>, Error> {
         let (sender, receiver) = unbounded_channel();
         self.sender
             .send(Msg::ChannelOpenDirectTcpIp {
@@ -418,10 +338,10 @@ impl<H: Handler> Handle<H> {
     /// the client, prefer to use the Channel returned from the `open_*` methods.
     pub async fn data(&self, id: ChannelId, data: CryptoVec) -> Result<(), CryptoVec> {
         self.sender
-            .send(Msg::Data { id, data })
+            .send(Msg::Channel(id, ChannelMsg::Data { data }))
             .await
             .map_err(|e| match e.0 {
-                Msg::Data { data, .. } => data,
+                Msg::Channel(_, ChannelMsg::Data { data, .. }) => data,
                 _ => unreachable!(),
             })
     }
@@ -437,17 +357,17 @@ impl<H: Handler> Handle<H> {
         data: CryptoVec,
     ) -> Result<(), CryptoVec> {
         self.sender
-            .send(Msg::ExtendedData { id, data, ext })
+            .send(Msg::Channel(id, ChannelMsg::ExtendedData { data, ext }))
             .await
             .map_err(|e| match e.0 {
-                Msg::Data { data, .. } => data,
+                Msg::Channel(_, ChannelMsg::ExtendedData { data, .. }) => data,
                 _ => unreachable!(),
             })
     }
 
     /// Sends a disconnect message.
     pub async fn disconnect(
-        &mut self,
+        &self,
         reason: Disconnect,
         description: &str,
         language_tag: &str,
@@ -461,332 +381,6 @@ impl<H: Handler> Handle<H> {
             .await
             .map_err(|_| Error::SendError)?;
         Ok(())
-    }
-}
-
-impl Channel {
-    pub fn id(&self) -> ChannelId {
-        self.sender.id
-    }
-
-    /// Returns the min between the maximum packet size and the
-    /// remaining window size in the channel.
-    pub fn writable_packet_size(&self) -> usize {
-        self.max_packet_size.min(self.window_size) as usize
-    }
-
-    /// Request a pseudo-terminal with the given characteristics.
-    #[allow(clippy::too_many_arguments)] // length checked
-    pub async fn request_pty(
-        &mut self,
-        want_reply: bool,
-        term: &str,
-        col_width: u32,
-        row_height: u32,
-        pix_width: u32,
-        pix_height: u32,
-        terminal_modes: &[(Pty, u32)],
-    ) -> Result<(), Error> {
-        self.sender
-            .sender
-            .send(Msg::RequestPty {
-                id: self.sender.id,
-                want_reply,
-                term: term.to_string(),
-                col_width,
-                row_height,
-                pix_width,
-                pix_height,
-                terminal_modes: terminal_modes.to_vec(),
-            })
-            .await
-            .map_err(|_| Error::SendError)?;
-        Ok(())
-    }
-
-    /// Request a remote shell.
-    pub async fn request_shell(&mut self, want_reply: bool) -> Result<(), Error> {
-        self.sender
-            .sender
-            .send(Msg::RequestShell {
-                id: self.sender.id,
-                want_reply,
-            })
-            .await
-            .map_err(|_| Error::SendError)?;
-        Ok(())
-    }
-
-    /// Execute a remote program (will be passed to a shell). This can
-    /// be used to implement scp (by calling a remote scp and
-    /// tunneling to its standard input).
-    pub async fn exec<A: Into<String>>(
-        &mut self,
-        want_reply: bool,
-        command: A,
-    ) -> Result<(), Error> {
-        self.sender
-            .sender
-            .send(Msg::Exec {
-                id: self.sender.id,
-                want_reply,
-                command: command.into(),
-            })
-            .await
-            .map_err(|e| {
-                debug!("e = {:?}", e);
-                Error::SendError
-            })?;
-        Ok(())
-    }
-
-    /// Signal a remote process.
-    pub async fn signal(&mut self, signal: Sig) -> Result<(), Error> {
-        self.sender
-            .sender
-            .send(Msg::Signal {
-                id: self.sender.id,
-                signal,
-            })
-            .await
-            .map_err(|_| Error::SendError)?;
-        Ok(())
-    }
-
-    /// Request the start of a subsystem with the given name.
-    pub async fn request_subsystem<A: Into<String>>(
-        &mut self,
-        want_reply: bool,
-        name: A,
-    ) -> Result<(), Error> {
-        self.sender
-            .sender
-            .send(Msg::RequestSubsystem {
-                id: self.sender.id,
-                want_reply,
-                name: name.into(),
-            })
-            .await
-            .map_err(|_| Error::SendError)?;
-        Ok(())
-    }
-
-    /// Request the forwarding of a remote port to the client. The
-    /// server will then open forwarding channels (which cause the
-    /// client to call `.channel_open_forwarded_tcpip()`).
-    pub async fn tcpip_forward<A: Into<String>>(
-        &mut self,
-        want_reply: bool,
-        address: A,
-        port: u32,
-    ) -> Result<(), Error> {
-        self.sender
-            .sender
-            .send(Msg::TcpIpForward {
-                want_reply,
-                address: address.into(),
-                port,
-            })
-            .await
-            .map_err(|_| Error::SendError)?;
-        Ok(())
-    }
-
-    /// Cancel a previous forwarding request.
-    pub async fn cancel_tcpip_forward<A: Into<String>>(
-        &mut self,
-        want_reply: bool,
-        address: A,
-        port: u32,
-    ) -> Result<(), Error> {
-        self.sender
-            .sender
-            .send(Msg::CancelTcpIpForward {
-                want_reply,
-                address: address.into(),
-                port,
-            })
-            .await
-            .map_err(|_| Error::SendError)?;
-        Ok(())
-    }
-
-    /// Request X11 forwarding through an already opened X11
-    /// channel. See
-    /// [RFC4254](https://tools.ietf.org/html/rfc4254#section-6.3.1)
-    /// for security issues related to cookies.
-    pub async fn request_x11<A: Into<String>, B: Into<String>>(
-        &mut self,
-        want_reply: bool,
-        single_connection: bool,
-        x11_authentication_protocol: A,
-        x11_authentication_cookie: B,
-        x11_screen_number: u32,
-    ) -> Result<(), Error> {
-        self.sender
-            .sender
-            .send(Msg::RequestX11 {
-                id: self.sender.id,
-                want_reply,
-                single_connection,
-                x11_authentication_protocol: x11_authentication_protocol.into(),
-                x11_authentication_cookie: x11_authentication_cookie.into(),
-                x11_screen_number,
-            })
-            .await
-            .map_err(|_| Error::SendError)?;
-        Ok(())
-    }
-
-    /// Set a remote environment variable.
-    pub async fn set_env<A: Into<String>, B: Into<String>>(
-        &mut self,
-        want_reply: bool,
-        variable_name: A,
-        variable_value: B,
-    ) -> Result<(), Error> {
-        self.sender
-            .sender
-            .send(Msg::SetEnv {
-                id: self.sender.id,
-                want_reply,
-                variable_name: variable_name.into(),
-                variable_value: variable_value.into(),
-            })
-            .await
-            .map_err(|_| Error::SendError)?;
-        Ok(())
-    }
-
-    /// Inform the server that our window size has changed.
-    pub async fn window_change(
-        &mut self,
-        col_width: u32,
-        row_height: u32,
-        pix_width: u32,
-        pix_height: u32,
-    ) -> Result<(), Error> {
-        self.sender
-            .sender
-            .send(Msg::WindowChange {
-                id: self.sender.id,
-                col_width,
-                row_height,
-                pix_width,
-                pix_height,
-            })
-            .await
-            .map_err(|_| Error::SendError)?;
-        Ok(())
-    }
-
-    /// Send data to a channel.
-    pub async fn data<R: tokio::io::AsyncReadExt + std::marker::Unpin>(
-        &mut self,
-        data: R,
-    ) -> Result<(), Error> {
-        self.send_data(None, data).await
-    }
-
-    /// Send data to a channel. The number of bytes added to the
-    /// "sending pipeline" (to be processed by the event loop) is
-    /// returned.
-    pub async fn extended_data<R: tokio::io::AsyncReadExt + std::marker::Unpin>(
-        &mut self,
-        ext: u32,
-        data: R,
-    ) -> Result<(), Error> {
-        self.send_data(Some(ext), data).await
-    }
-
-    async fn send_data<R: tokio::io::AsyncReadExt + std::marker::Unpin>(
-        &mut self,
-        ext: Option<u32>,
-        mut data: R,
-    ) -> Result<(), Error> {
-        let mut total = 0;
-        loop {
-            // wait for the window to be restored.
-            while self.window_size == 0 {
-                match self.receiver.recv().await {
-                    Some(OpenChannelMsg::Msg(ChannelMsg::WindowAdjusted { new_size })) => {
-                        debug!("window adjusted: {:?}", new_size);
-                        self.window_size = new_size;
-                        break;
-                    }
-                    Some(OpenChannelMsg::Msg(msg)) => {
-                        debug!("unexpected channel msg: {:?}", msg);
-                    }
-                    Some(_) => debug!("unexpected channel msg"),
-                    None => break,
-                }
-            }
-            debug!(
-                "sending data, self.window_size = {:?}, self.max_packet_size = {:?}, total = {:?}",
-                self.window_size, self.max_packet_size, total
-            );
-            let sendable = self.window_size.min(self.max_packet_size) as usize;
-            debug!("sendable {:?}", sendable);
-            let mut c = CryptoVec::new_zeroed(sendable);
-            let n = data.read(&mut c[..]).await?;
-            total += n;
-            c.resize(n);
-            self.window_size -= n as u32;
-            self.send_data_packet(ext, c).await?;
-            if n == 0 {
-                break;
-            } else if self.window_size > 0 {
-                continue;
-            }
-        }
-        Ok(())
-    }
-
-    async fn send_data_packet(&mut self, ext: Option<u32>, data: CryptoVec) -> Result<(), Error> {
-        self.sender
-            .sender
-            .send(if let Some(ext) = ext {
-                Msg::ExtendedData {
-                    id: self.sender.id,
-                    ext,
-                    data,
-                }
-            } else {
-                Msg::Data {
-                    id: self.sender.id,
-                    data,
-                }
-            })
-            .await
-            .map_err(|e| {
-                error!("{:?}", e);
-                Error::SendError
-            })?;
-        Ok(())
-    }
-
-    pub async fn eof(&mut self) -> Result<(), Error> {
-        self.sender
-            .sender
-            .send(Msg::Eof { id: self.sender.id })
-            .await
-            .map_err(|_| Error::SendError)?;
-        Ok(())
-    }
-
-    /// Wait for data to come.
-    pub async fn wait(&mut self) -> Option<ChannelMsg> {
-        loop {
-            match self.receiver.recv().await {
-                Some(OpenChannelMsg::Msg(ChannelMsg::WindowAdjusted { new_size })) => {
-                    self.window_size += new_size;
-                    return Some(ChannelMsg::WindowAdjusted { new_size });
-                }
-                Some(OpenChannelMsg::Msg(msg)) => return Some(msg),
-                None => return None,
-                _ => {}
-            }
-        }
     }
 }
 
@@ -989,33 +583,37 @@ impl Session {
                         Some(Msg::Disconnect { reason, description, language_tag }) => {
                             self.disconnect(reason, &description, &language_tag)
                         },
-                        Some(Msg::Data { data, id }) => { self.data(id, data) },
-                        Some(Msg::Eof { id }) => { self.eof(id); },
-                        Some(Msg::ExtendedData { data, ext, id }) => { self.extended_data(id, ext, data); },
-                        Some(Msg::RequestPty { id, want_reply, term, col_width, row_height, pix_width, pix_height, terminal_modes }) => {
+                        Some(Msg::Channel(id, ChannelMsg::Data { data })) => { self.data(id, data) },
+                        Some(Msg::Channel(id, ChannelMsg::Eof)) => { self.eof(id); },
+                        Some(Msg::Channel(id, ChannelMsg::ExtendedData { data, ext })) => { self.extended_data(id, ext, data); },
+                        Some(Msg::Channel(id, ChannelMsg::RequestPty { want_reply, term, col_width, row_height, pix_width, pix_height, terminal_modes })) => {
                             self.request_pty(id, want_reply, &term, col_width, row_height, pix_width, pix_height, &terminal_modes)
                         },
-                        Some(Msg::WindowChange { id, col_width, row_height, pix_width, pix_height }) => {
+                        Some(Msg::Channel(id, ChannelMsg::WindowChange { col_width, row_height, pix_width, pix_height })) => {
                             self.window_change(id, col_width, row_height, pix_width, pix_height)
                         },
-                        Some(Msg::RequestX11 { id, want_reply, single_connection, x11_authentication_protocol, x11_authentication_cookie, x11_screen_number }) => {
+                        Some(Msg::Channel(id, ChannelMsg::RequestX11 { want_reply, single_connection, x11_authentication_protocol, x11_authentication_cookie, x11_screen_number })) => {
                             self.request_x11(id, want_reply, single_connection, &x11_authentication_protocol, &x11_authentication_cookie, x11_screen_number)
                         },
-                        Some(Msg::SetEnv { id, want_reply, variable_name, variable_value }) => {
+                        Some(Msg::Channel(id, ChannelMsg::SetEnv { want_reply, variable_name, variable_value })) => {
                             self.set_env(id, want_reply, &variable_name, &variable_value)
                         },
-                        Some(Msg::RequestShell { id, want_reply }) => {
+                        Some(Msg::Channel(id, ChannelMsg::RequestShell { want_reply })) => {
                             self.request_shell(want_reply, id)
                         },
-                        Some(Msg::Exec { id, want_reply, command }) => {
+                        Some(Msg::Channel(id, ChannelMsg::Exec { want_reply, command })) => {
                             self.exec(id, want_reply, &command)
                         },
-                        Some(Msg::Signal { id, signal }) => {
+                        Some(Msg::Channel(id, ChannelMsg::Signal { signal })) => {
                             self.signal(id, signal)
                         },
-                        Some(Msg::RequestSubsystem { id, want_reply, name }) => {
+                        Some(Msg::Channel(id, ChannelMsg::RequestSubsystem { want_reply, name })) => {
                             self.request_subsystem(want_reply, id, &name)
                         },
+                        Some(_) => {
+                            debug!("unimplemented (intended for server?) message: {:?}", msg);
+                            self.unimplemented(0);
+                        }
                         None => {
                             self.common.disconnected = true;
                             break
@@ -1111,7 +709,7 @@ impl Session {
     /// Send a `ChannelMsg` from the background handler to the client.
     pub fn send_channel_msg(&self, channel: ChannelId, msg: ChannelMsg) -> bool {
         if let Some(chan) = self.channels.get(&channel) {
-            chan.send(OpenChannelMsg::Msg(msg)).unwrap_or(());
+            chan.send(msg).unwrap_or(());
             true
         } else {
             false
@@ -1365,7 +963,7 @@ pub trait Handler: Sized {
     ) -> Self::FutureUnit {
         if let Some(channel) = session.channels.get(&id) {
             channel
-                .send(OpenChannelMsg::Open {
+                .send(ChannelMsg::Open {
                     id,
                     max_packet_size,
                     window_size,
@@ -1381,8 +979,7 @@ pub trait Handler: Sized {
     #[allow(unused_variables)]
     fn channel_success(self, channel: ChannelId, session: Session) -> Self::FutureUnit {
         if let Some(chan) = session.channels.get(&channel) {
-            chan.send(OpenChannelMsg::Msg(ChannelMsg::Success))
-                .unwrap_or(())
+            chan.send(ChannelMsg::Success).unwrap_or(())
         }
         self.finished(session)
     }
@@ -1398,8 +995,7 @@ pub trait Handler: Sized {
     #[allow(unused_variables)]
     fn channel_eof(self, channel: ChannelId, session: Session) -> Self::FutureUnit {
         if let Some(chan) = session.channels.get(&channel) {
-            chan.send(OpenChannelMsg::Msg(ChannelMsg::Eof))
-                .unwrap_or(())
+            chan.send(ChannelMsg::Eof).unwrap_or(())
         }
         self.finished(session)
     }
@@ -1480,9 +1076,9 @@ pub trait Handler: Sized {
     #[allow(unused_variables)]
     fn data(self, channel: ChannelId, data: &[u8], session: Session) -> Self::FutureUnit {
         if let Some(chan) = session.channels.get(&channel) {
-            chan.send(OpenChannelMsg::Msg(ChannelMsg::Data {
+            chan.send(ChannelMsg::Data {
                 data: CryptoVec::from_slice(data),
-            }))
+            })
             .unwrap_or(())
         }
         self.finished(session)
@@ -1501,10 +1097,10 @@ pub trait Handler: Sized {
         session: Session,
     ) -> Self::FutureUnit {
         if let Some(chan) = session.channels.get(&channel) {
-            chan.send(OpenChannelMsg::Msg(ChannelMsg::ExtendedData {
+            chan.send(ChannelMsg::ExtendedData {
                 ext,
                 data: CryptoVec::from_slice(data),
-            }))
+            })
             .unwrap_or(())
         }
         self.finished(session)
@@ -1521,7 +1117,7 @@ pub trait Handler: Sized {
         session: Session,
     ) -> Self::FutureUnit {
         if let Some(chan) = session.channels.get(&channel) {
-            chan.send(OpenChannelMsg::Msg(ChannelMsg::XonXoff { client_can_do }))
+            chan.send(ChannelMsg::XonXoff { client_can_do })
                 .unwrap_or(())
         }
         self.finished(session)
@@ -1536,7 +1132,7 @@ pub trait Handler: Sized {
         session: Session,
     ) -> Self::FutureUnit {
         if let Some(chan) = session.channels.get(&channel) {
-            chan.send(OpenChannelMsg::Msg(ChannelMsg::ExitStatus { exit_status }))
+            chan.send(ChannelMsg::ExitStatus { exit_status })
                 .unwrap_or(())
         }
         self.finished(session)
@@ -1554,12 +1150,12 @@ pub trait Handler: Sized {
         session: Session,
     ) -> Self::FutureUnit {
         if let Some(chan) = session.channels.get(&channel) {
-            chan.send(OpenChannelMsg::Msg(ChannelMsg::ExitSignal {
+            chan.send(ChannelMsg::ExitSignal {
                 signal_name,
                 core_dumped,
                 error_message: error_message.to_string(),
                 lang_tag: lang_tag.to_string(),
-            }))
+            })
             .unwrap_or(())
         }
         self.finished(session)
@@ -1581,7 +1177,7 @@ pub trait Handler: Sized {
             new_size -= enc.flush_pending(channel) as u32;
         }
         if let Some(chan) = session.channels.get(&channel) {
-            chan.send(OpenChannelMsg::Msg(ChannelMsg::WindowAdjusted { new_size }))
+            chan.send(ChannelMsg::WindowAdjusted { new_size })
                 .unwrap_or(())
         }
         self.finished(session)

--- a/russh/src/client/session.rs
+++ b/russh/src/client/session.rs
@@ -360,4 +360,13 @@ impl Session {
             0
         }
     }
+
+    pub(crate) fn unimplemented(&mut self, packet_id: u32) {
+        if let Some(ref mut enc) = self.common.encrypted {
+            push_packet!(enc.write, {
+                enc.write.push(msg::UNIMPLEMENTED);
+                enc.write.push_u32_be(packet_id);
+            });
+        }
+    }
 }

--- a/russh/src/lib.rs
+++ b/russh/src/lib.rs
@@ -702,7 +702,7 @@ mod test_compress {
         channel.data(data).await.unwrap();
         let msg = channel.wait().await.unwrap();
         match msg {
-            ChannelMsg::Data { data: msg_data } => {
+            channels::ChannelMsg::Data { data: msg_data } => {
                 assert_eq!(*data, *msg_data)
             }
             msg => panic!("Unexpected message {:?}", msg),

--- a/russh/src/lib.rs
+++ b/russh/src/lib.rs
@@ -320,8 +320,9 @@ macro_rules! push_packet {
     }};
 }
 
-mod session;
+pub mod channels;
 mod parsing;
+mod session;
 
 /// Server side of this library.
 pub mod server;
@@ -636,7 +637,7 @@ impl Display for ChannelId {
 
 /// The parameters of a channel.
 #[derive(Debug)]
-pub(crate) struct Channel {
+pub(crate) struct ChannelParams {
     recipient_channel: u32,
     sender_channel: ChannelId,
     recipient_window_size: u32,
@@ -647,35 +648,6 @@ pub(crate) struct Channel {
     pub confirmed: bool,
     wants_reply: bool,
     pending_data: std::collections::VecDeque<(CryptoVec, Option<u32>, usize)>,
-}
-
-#[derive(Debug)]
-pub enum ChannelMsg {
-    Data {
-        data: CryptoVec,
-    },
-    ExtendedData {
-        data: CryptoVec,
-        ext: u32,
-    },
-    Eof,
-    Close,
-    XonXoff {
-        client_can_do: bool,
-    },
-    ExitStatus {
-        exit_status: u32,
-    },
-    ExitSignal {
-        signal_name: Sig,
-        core_dumped: bool,
-        error_message: String,
-        lang_tag: String,
-    },
-    WindowAdjusted {
-        new_size: u32,
-    },
-    Success,
 }
 
 #[cfg(test)]

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -265,6 +265,24 @@ impl Encrypted {
             } else if method == b"publickey" {
                 self.server_read_auth_request_pk(until, handler, buf, auth_user, user, r)
                     .await
+            } else if method == b"none" {
+                let auth_request = if let EncryptedState::WaitingAuthRequest(ref mut a) = self.state
+                {
+                    a
+                } else {
+                    unreachable!()
+                };
+                let (handler, auth) = handler.auth_none(user).await?;
+                if let Auth::Accept = auth {
+                    server_auth_request_success(&mut self.write);
+                    self.state = EncryptedState::InitCompression;
+                } else {
+                    auth_user.clear();
+                    auth_request.methods -= MethodSet::NONE;
+                    auth_request.partial_success = false;
+                    reject_auth_request(until, &mut self.write, auth_request).await;
+                }
+                Ok(handler)
             } else if method == b"keyboard-interactive" {
                 let auth_request = if let EncryptedState::WaitingAuthRequest(ref mut a) = self.state
                 {
@@ -827,28 +845,45 @@ impl Session {
                 originator_address,
                 originator_port,
             } => {
-                self.confirm_channel_open(&msg, channel);
-                handler
+                let mut result = handler
                     .channel_open_x11(sender_channel, originator_address, *originator_port, self)
-                    .await
+                    .await;
+                if let Ok((_, s)) = &mut result {
+                    s.confirm_channel_open(&msg, channel);
+                }
+                result
             }
-            ChannelType::DirectTcpip {
-                host_to_connect,
-                port_to_connect,
-                originator_address,
-                originator_port,
-            } => {
-                self.confirm_channel_open(&msg, channel);
-                handler
+            ChannelType::DirectTcpip(d) => {
+                let mut result = handler
                     .channel_open_direct_tcpip(
                         sender_channel,
-                        host_to_connect,
-                        *port_to_connect,
-                        originator_address,
-                        *originator_port,
+                        &d.host_to_connect,
+                        d.port_to_connect,
+                        &d.originator_address,
+                        d.originator_port,
                         self,
                     )
-                    .await
+                    .await;
+                if let Ok((_, s)) = &mut result {
+                    s.confirm_channel_open(&msg, channel);
+                }
+                result
+            }
+            ChannelType::ForwardedTcpIp(d) => {
+                let mut result = handler
+                    .channel_open_forwarded_tcpip(
+                        sender_channel,
+                        &d.host_to_connect,
+                        d.port_to_connect,
+                        &d.originator_address,
+                        d.originator_port,
+                        self,
+                    )
+                    .await;
+                if let Ok((_, s)) = &mut result {
+                    s.confirm_channel_open(&msg, channel);
+                }
+                result
             }
             ChannelType::Unknown { typ } => {
                 debug!("unknown channel type: {}", String::from_utf8_lossy(typ));
@@ -861,7 +896,7 @@ impl Session {
         }
     }
 
-    fn confirm_channel_open(&mut self, open: &OpenChannelMessage, channel: Channel) {
+    fn confirm_channel_open(&mut self, open: &OpenChannelMessage, channel: ChannelParams) {
         if let Some(ref mut enc) = self.common.encrypted {
             open.confirm(
                 &mut enc.write,

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -14,6 +14,7 @@
 //
 
 use std;
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -246,6 +247,21 @@ pub trait Handler: Sized {
     /// Called when a new TCP/IP is created.
     #[allow(unused_variables)]
     fn channel_open_direct_tcpip(
+        self,
+        channel: ChannelId,
+        host_to_connect: &str,
+        port_to_connect: u32,
+        originator_address: &str,
+        originator_port: u32,
+        session: Session,
+    ) -> Self::FutureUnit {
+        self.finished(session)
+    }
+
+    /// Called when a new forwarded connection comes in.
+    /// https://www.rfc-editor.org/rfc/rfc4254#section-7
+    #[allow(unused_variables)]
+    fn channel_open_forwarded_tcpip(
         self,
         channel: ChannelId,
         host_to_connect: &str,

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -526,7 +526,6 @@ where
     let (sender, receiver) = tokio::sync::mpsc::channel(10);
     let handle = server::session::Handle { sender };
     let session = Session {
-        session_id: get_session_id(),
         target_window_size: common.config.window_size,
         common,
         receiver,

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -15,13 +15,16 @@
 
 use std;
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use futures::future::Future;
 use russh_keys::key;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::pin;
+use tokio::task::JoinHandle;
 
 use crate::cipher::{clear, CipherPair, OpeningKey};
 use crate::session::*;
@@ -155,6 +158,12 @@ pub trait Handler: Sized {
     /// default handlers.
     fn finished(self, session: Session) -> Self::FutureUnit;
 
+    /// Called when a session disconnects.
+    #[allow(unused_variables)]
+    fn disconnected(self, session: Session) -> Self::FutureUnit {
+        self.finished(session)
+    }
+
     /// Check authentication using the "none" method. Russh makes
     /// sure rejection happens in time `config.auth_rejection_time`,
     /// except if this method takes more than that.
@@ -198,6 +207,12 @@ pub trait Handler: Sized {
         self.finished_auth(Auth::Reject)
     }
 
+    /// Called when authentication succeeds for a session.
+    #[allow(unused_variables)]
+    fn auth_succeeded(self, session: Session) -> Self::FutureUnit {
+        self.finished(session)
+    }
+
     /// Called when the client closes a channel.
     #[allow(unused_variables)]
     fn channel_close(self, channel: ChannelId, session: Session) -> Self::FutureUnit {
@@ -228,7 +243,7 @@ pub trait Handler: Sized {
         self.finished(session)
     }
 
-    /// Called when a new channel is created.
+    /// Called when a new TCP/IP is created.
     #[allow(unused_variables)]
     fn channel_open_direct_tcpip(
         self,
@@ -446,17 +461,42 @@ async fn start_reading<R: AsyncRead + Unpin>(
     Ok((n, stream_read, buffer, cipher))
 }
 
-pub async fn run_stream<H: Handler, R>(
+pub struct RunningSession<H: Handler> {
+    handle: Handle,
+    join: JoinHandle<Result<(), H::Error>>,
+}
+
+impl<H: Handler> RunningSession<H> {
+    /// Returns a copy of the handle for the session.
+    pub fn handle(&self) -> Handle {
+        self.handle.clone()
+    }
+}
+
+impl<H: Handler> Future for RunningSession<H> {
+    type Output = Result<(), H::Error>;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        match Future::poll(Pin::new(&mut self.join), cx) {
+            Poll::Ready(r) => Poll::Ready(match r {
+                Ok(Ok(x)) => Ok(x),
+                Err(e) => Err(crate::Error::from(e).into()),
+                Ok(Err(e)) => Err(e),
+            }),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+pub async fn run_stream<H, R>(
     config: Arc<Config>,
     mut stream: R,
-    mut handler: H,
-) -> Result<H, H::Error>
+    handler: H,
+) -> Result<RunningSession<H>, H::Error>
 where
-    R: AsyncRead + AsyncWrite + Unpin,
+    H: Handler + Send + 'static,
+    R: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
-    let delay = config.connection_timeout;
     // Writing SSH id.
-    let mut decomp = CryptoVec::new();
     let mut write_buffer = SSHBuffer::new();
     write_buffer.send_ssh_id(config.as_ref().server_id.as_bytes());
     stream
@@ -465,147 +505,24 @@ where
         .map_err(crate::Error::from)?;
 
     // Reading SSH id and allocating a session.
-    let mut stream = SshRead::new(&mut stream);
+    let mut stream = SshRead::new(stream);
     let common = read_ssh_id(config, &mut stream).await?;
     let (sender, receiver) = tokio::sync::mpsc::channel(10);
-    let mut session = Session {
+    let handle = server::session::Handle { sender };
+    let session = Session {
+        session_id: get_session_id(),
         target_window_size: common.config.window_size,
         common,
         receiver,
-        sender: server::session::Handle { sender },
+        sender: handle.clone(),
         pending_reads: Vec::new(),
         pending_len: 0,
+        channels: HashMap::new(),
     };
-    session.flush()?;
-    stream
-        .write_all(&session.common.write_buffer.buffer)
-        .await
-        .map_err(crate::Error::from)?;
-    session.common.write_buffer.buffer.clear();
 
-    let (stream_read, mut stream_write) = stream.split();
-    let buffer = SSHBuffer::new();
+    let join = tokio::spawn(session.run(stream, handler));
 
-    // Allow handing out references to the cipher
-    let mut opening_cipher = Box::new(clear::Key) as Box<dyn OpeningKey + Send>;
-    std::mem::swap(
-        &mut opening_cipher,
-        &mut session.common.cipher.remote_to_local,
-    );
-
-    let reading = start_reading(stream_read, buffer, opening_cipher);
-    pin!(reading);
-    let mut is_reading = None;
-
-    #[allow(clippy::panic)] // false positive in macro
-    while !session.common.disconnected {
-        tokio::select! {
-            r = &mut reading => {
-                let (stream_read, buffer, mut opening_cipher) = match r {
-                    Ok((_, stream_read, buffer, opening_cipher)) => (stream_read, buffer, opening_cipher),
-                    Err(e) => return Err(e.into())
-                };
-                if buffer.buffer.len() < 5 {
-                    is_reading = Some((stream_read, buffer, opening_cipher));
-                    break
-                }
-                #[allow(clippy::indexing_slicing)] // length checked
-                let buf = if let Some(ref mut enc) = session.common.encrypted {
-                    let d = enc.decompress.decompress(
-                        &buffer.buffer[5..],
-                        &mut decomp,
-                    );
-                    if let Ok(buf) = d {
-                        buf
-                    } else {
-                        debug!("err = {:?}", d);
-                        is_reading = Some((stream_read, buffer, opening_cipher));
-                        break
-                    }
-                } else {
-                    &buffer.buffer[5..]
-                };
-                if !buf.is_empty() {
-                    #[allow(clippy::indexing_slicing)] // length checked
-                    if buf[0] == crate::msg::DISCONNECT {
-                        debug!("break");
-                        is_reading = Some((stream_read, buffer, opening_cipher));
-                        break;
-                    } else if buf[0] > 4 {
-                        std::mem::swap(&mut opening_cipher, &mut session.common.cipher.remote_to_local);
-                        // TODO it'd be cleaner to just pass cipher to reply()
-                        match reply(session, handler, buf).await {
-                            Ok((h, s)) => {
-                                handler = h;
-                                session = s;
-                            },
-                            Err(e) => return Err(e),
-                        }
-                        std::mem::swap(&mut opening_cipher, &mut session.common.cipher.remote_to_local);
-                    }
-                }
-                reading.set(start_reading(stream_read, buffer, opening_cipher));
-            }
-            _ = timeout(delay) => {
-                debug!("timeout");
-                break
-            },
-            msg = session.receiver.recv(), if !session.is_rekeying() => {
-                match msg {
-                    Some((id, ChannelMsg::Data { data })) => {
-                        session.data(id, data);
-                    }
-                    Some((id, ChannelMsg::ExtendedData { ext, data })) => {
-                        session.extended_data(id, ext, data);
-                    }
-                    Some((id, ChannelMsg::Eof)) => {
-                        session.eof(id);
-                    }
-                    Some((id, ChannelMsg::Close)) => {
-                        session.close(id);
-                    }
-                    Some((id, ChannelMsg::Success)) => {
-                        session.channel_success(id);
-                    }
-                    Some((id, ChannelMsg::XonXoff { client_can_do })) => {
-                        session.xon_xoff_request(id, client_can_do);
-                    }
-                    Some((id, ChannelMsg::ExitStatus { exit_status })) => {
-                        session.exit_status_request(id, exit_status);
-                    }
-                    Some((id, ChannelMsg::ExitSignal { signal_name, core_dumped, error_message, lang_tag })) => {
-                        session.exit_signal_request(id, signal_name, core_dumped, &error_message, &lang_tag);
-                    }
-                    Some((id, ChannelMsg::WindowAdjusted { new_size })) => {
-                        debug!("window adjusted to {:?} for channel {:?}", new_size, id);
-                    }
-                    None => {
-                        debug!("session.receiver: received None");
-                    }
-                }
-            }
-        }
-        session.flush()?;
-        stream_write
-            .write_all(&session.common.write_buffer.buffer)
-            .await
-            .map_err(crate::Error::from)?;
-        session.common.write_buffer.buffer.clear();
-    }
-    debug!("disconnected");
-    // Shutdown
-    stream_write.shutdown().await.map_err(crate::Error::from)?;
-    loop {
-        if let Some((stream_read, buffer, opening_cipher)) = is_reading.take() {
-            reading.set(start_reading(stream_read, buffer, opening_cipher));
-        }
-        let (n, r, b, opening_cipher) = (&mut reading).await?;
-        is_reading = Some((r, b, opening_cipher));
-        if n == 0 {
-            break;
-        }
-    }
-    Ok(handler)
+    Ok(RunningSession { handle, join })
 }
 
 async fn read_ssh_id<R: AsyncRead + Unpin>(

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -1,10 +1,4 @@
-use std::{
-    collections::HashMap,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
-};
+use std::{collections::HashMap, sync::Arc};
 
 use russh_keys::encoding::Encoding;
 use tokio::sync::mpsc::{Receiver, Sender, UnboundedReceiver};
@@ -19,15 +13,8 @@ use crate::{
     msg,
 };
 
-static SESSION_COUNTER: AtomicUsize = AtomicUsize::new(0);
-
-pub(crate) fn get_session_id() -> usize {
-    SESSION_COUNTER.fetch_add(1, Ordering::SeqCst)
-}
-
 /// A connected server session. This type is unique to a client.
 pub struct Session {
-    pub(crate) session_id: usize,
     pub(crate) common: CommonSession<Arc<Config>>,
     pub(crate) sender: Handle,
     pub(crate) receiver: Receiver<Msg>,
@@ -454,12 +441,6 @@ impl Session {
         }
 
         Ok(())
-    }
-
-    /// Application-unqiue session ID. Can be used for identifying the session
-    /// across method calls.
-    pub fn id(&self) -> usize {
-        self.session_id
     }
 
     /// Get a handle to this session.

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -1,36 +1,77 @@
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 use russh_keys::encoding::Encoding;
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::{Receiver, Sender, UnboundedReceiver};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, AsyncWriteExt},
+    sync::mpsc::{unbounded_channel, UnboundedSender},
+};
 
 use super::*;
-use crate::msg;
+use crate::{
+    channels::{Channel, ChannelMsg},
+    msg,
+};
+
+static SESSION_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+pub(crate) fn get_session_id() -> usize {
+    SESSION_COUNTER.fetch_add(1, Ordering::SeqCst)
+}
 
 /// A connected server session. This type is unique to a client.
 pub struct Session {
+    pub(crate) session_id: usize,
     pub(crate) common: CommonSession<Arc<Config>>,
     pub(crate) sender: Handle,
-    pub(crate) receiver: Receiver<(ChannelId, ChannelMsg)>,
+    pub(crate) receiver: Receiver<Msg>,
     pub(crate) target_window_size: u32,
     pub(crate) pending_reads: Vec<CryptoVec>,
     pub(crate) pending_len: u32,
+    pub(crate) channels: HashMap<ChannelId, UnboundedSender<ChannelMsg>>,
+}
+#[derive(Debug)]
+pub enum Msg {
+    ChannelOpenSession {
+        sender: UnboundedSender<ChannelMsg>,
+    },
+    ChannelOpenDirectTcpIp {
+        host_to_connect: String,
+        port_to_connect: u32,
+        originator_address: String,
+        originator_port: u32,
+        sender: UnboundedSender<ChannelMsg>,
+    },
+    Channel(ChannelId, ChannelMsg),
+}
+
+impl From<(ChannelId, ChannelMsg)> for Msg {
+    fn from((id, msg): (ChannelId, ChannelMsg)) -> Self {
+        Msg::Channel(id, msg)
+    }
 }
 
 #[derive(Clone)]
 /// Handle to a session, used to send messages to a client outside of
 /// the request/response cycle.
 pub struct Handle {
-    pub(crate) sender: Sender<(ChannelId, ChannelMsg)>,
+    pub(crate) sender: Sender<Msg>,
 }
 
 impl Handle {
     /// Send data to the session referenced by this handler.
     pub async fn data(&mut self, id: ChannelId, data: CryptoVec) -> Result<(), CryptoVec> {
         self.sender
-            .send((id, ChannelMsg::Data { data }))
+            .send(Msg::Channel(id, ChannelMsg::Data { data }))
             .await
             .map_err(|e| match e.0 {
-                (_, ChannelMsg::Data { data }) => data,
+                Msg::Channel(_, ChannelMsg::Data { data }) => data,
                 _ => unreachable!(),
             })
     }
@@ -43,10 +84,10 @@ impl Handle {
         data: CryptoVec,
     ) -> Result<(), CryptoVec> {
         self.sender
-            .send((id, ChannelMsg::ExtendedData { ext, data }))
+            .send(Msg::Channel(id, ChannelMsg::ExtendedData { ext, data }))
             .await
             .map_err(|e| match e.0 {
-                (_, ChannelMsg::ExtendedData { data, .. }) => data,
+                Msg::Channel(_, ChannelMsg::ExtendedData { data, .. }) => data,
                 _ => unreachable!(),
             })
     }
@@ -54,7 +95,7 @@ impl Handle {
     /// Send EOF to the session referenced by this handler.
     pub async fn eof(&mut self, id: ChannelId) -> Result<(), ()> {
         self.sender
-            .send((id, ChannelMsg::Eof))
+            .send(Msg::Channel(id, ChannelMsg::Eof))
             .await
             .map_err(|_| ())
     }
@@ -62,7 +103,7 @@ impl Handle {
     /// Send success to the session referenced by this handler.
     pub async fn channel_success(&mut self, id: ChannelId) -> Result<(), ()> {
         self.sender
-            .send((id, ChannelMsg::Success))
+            .send(Msg::Channel(id, ChannelMsg::Success))
             .await
             .map_err(|_| ())
     }
@@ -70,7 +111,7 @@ impl Handle {
     /// Close a channel.
     pub async fn close(&mut self, id: ChannelId) -> Result<(), ()> {
         self.sender
-            .send((id, ChannelMsg::Close))
+            .send(Msg::Channel(id, ChannelMsg::Close))
             .await
             .map_err(|_| ())
     }
@@ -80,7 +121,7 @@ impl Handle {
     /// [RFC4254](https://tools.ietf.org/html/rfc4254#section-6.8).
     pub async fn xon_xoff_request(&mut self, id: ChannelId, client_can_do: bool) -> Result<(), ()> {
         self.sender
-            .send((id, ChannelMsg::XonXoff { client_can_do }))
+            .send(Msg::Channel(id, ChannelMsg::XonXoff { client_can_do }))
             .await
             .map_err(|_| ())
     }
@@ -88,9 +129,78 @@ impl Handle {
     /// Send the exit status of a program.
     pub async fn exit_status_request(&mut self, id: ChannelId, exit_status: u32) -> Result<(), ()> {
         self.sender
-            .send((id, ChannelMsg::ExitStatus { exit_status }))
+            .send(Msg::Channel(id, ChannelMsg::ExitStatus { exit_status }))
             .await
             .map_err(|_| ())
+    }
+
+    /// Request a session channel (the most basic type of
+    /// channel). This function returns `Some(..)` immediately if the
+    /// connection is authenticated, but the channel only becomes
+    /// usable when it's confirmed by the server, as indicated by the
+    /// `confirmed` field of the corresponding `Channel`.
+    pub async fn channel_open_session(&mut self) -> Result<Channel<Msg>, Error> {
+        let (sender, receiver) = unbounded_channel();
+        self.sender
+            .send(Msg::ChannelOpenSession { sender })
+            .await
+            .map_err(|_| Error::SendError)?;
+        self.wait_channel_confirmation(receiver).await
+    }
+
+    /// Open a TCP/IP forwarding channel. This is usually done when a
+    /// connection comes to a locally forwarded TCP/IP port. See
+    /// [RFC4254](https://tools.ietf.org/html/rfc4254#section-7). The
+    /// TCP/IP packets can then be tunneled through the channel using
+    /// `.data()`.
+    pub async fn channel_open_direct_tcpip<A: Into<String>, B: Into<String>>(
+        &mut self,
+        host_to_connect: A,
+        port_to_connect: u32,
+        originator_address: B,
+        originator_port: u32,
+    ) -> Result<Channel<Msg>, Error> {
+        let (sender, receiver) = unbounded_channel();
+        self.sender
+            .send(Msg::ChannelOpenDirectTcpIp {
+                host_to_connect: host_to_connect.into(),
+                port_to_connect,
+                originator_address: originator_address.into(),
+                originator_port,
+                sender,
+            })
+            .await
+            .map_err(|_| Error::SendError)?;
+        self.wait_channel_confirmation(receiver).await
+    }
+
+    async fn wait_channel_confirmation(
+        &self,
+        mut receiver: UnboundedReceiver<ChannelMsg>,
+    ) -> Result<Channel<Msg>, Error> {
+        loop {
+            match receiver.recv().await {
+                Some(ChannelMsg::Open {
+                    id,
+                    max_packet_size,
+                    window_size,
+                }) => {
+                    return Ok(Channel {
+                        id,
+                        sender: self.sender.clone(),
+                        receiver,
+                        max_packet_size,
+                        window_size,
+                    });
+                }
+                None => {
+                    return Err(Error::Disconnect);
+                }
+                msg => {
+                    debug!("msg = {:?}", msg);
+                }
+            }
+        }
     }
 
     /// If the program was killed by a signal, send the details about the signal to the client.
@@ -103,7 +213,7 @@ impl Handle {
         lang_tag: String,
     ) -> Result<(), ()> {
         self.sender
-            .send((
+            .send(Msg::Channel(
                 id,
                 ChannelMsg::ExitSignal {
                     signal_name,
@@ -124,6 +234,165 @@ impl Session {
         } else {
             true
         }
+    }
+
+    pub(crate) async fn run<H, R>(
+        mut self,
+        mut stream: SshRead<R>,
+        mut handler: H,
+    ) -> Result<(), H::Error>
+    where
+        H: Handler + Send + 'static,
+        R: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        self.flush()?;
+        stream
+            .write_all(&self.common.write_buffer.buffer)
+            .await
+            .map_err(crate::Error::from)?;
+        self.common.write_buffer.buffer.clear();
+
+        let (stream_read, mut stream_write) = stream.split();
+        let buffer = SSHBuffer::new();
+
+        // Allow handing out references to the cipher
+        let mut opening_cipher = Box::new(clear::Key) as Box<dyn OpeningKey + Send>;
+        std::mem::swap(&mut opening_cipher, &mut self.common.cipher.remote_to_local);
+
+        let reading = start_reading(stream_read, buffer, opening_cipher);
+        pin!(reading);
+        let mut is_reading = None;
+        let mut decomp = CryptoVec::new();
+        let delay = self.common.config.connection_timeout;
+
+        #[allow(clippy::panic)] // false positive in macro
+        while !self.common.disconnected {
+            tokio::select! {
+                r = &mut reading => {
+                    let (stream_read, buffer, mut opening_cipher) = match r {
+                        Ok((_, stream_read, buffer, opening_cipher)) => (stream_read, buffer, opening_cipher),
+                        Err(e) => return Err(e.into())
+                    };
+                    if buffer.buffer.len() < 5 {
+                        is_reading = Some((stream_read, buffer, opening_cipher));
+                        break
+                    }
+                    #[allow(clippy::indexing_slicing)] // length checked
+                    let buf = if let Some(ref mut enc) = self.common.encrypted {
+                        let d = enc.decompress.decompress(
+                            &buffer.buffer[5..],
+                            &mut decomp,
+                        );
+                        if let Ok(buf) = d {
+                            buf
+                        } else {
+                            debug!("err = {:?}", d);
+                            is_reading = Some((stream_read, buffer, opening_cipher));
+                            break
+                        }
+                    } else {
+                        &buffer.buffer[5..]
+                    };
+                    if !buf.is_empty() {
+                        #[allow(clippy::indexing_slicing)] // length checked
+                        if buf[0] == crate::msg::DISCONNECT {
+                            debug!("break");
+                            is_reading = Some((stream_read, buffer, opening_cipher));
+                            break;
+                        } else if buf[0] > 4 {
+                            std::mem::swap(&mut opening_cipher, &mut self.common.cipher.remote_to_local);
+                            // TODO it'd be cleaner to just pass cipher to reply()
+                            match reply(self, handler, buf).await {
+                                Ok((h, s)) => {
+                                    handler = h;
+                                    self = s;
+                                },
+                                Err(e) => return Err(e),
+                            }
+                            std::mem::swap(&mut opening_cipher, &mut self.common.cipher.remote_to_local);
+                        }
+                    }
+                    reading.set(start_reading(stream_read, buffer, opening_cipher));
+                }
+                _ = timeout(delay) => {
+                    debug!("timeout");
+                    break
+                },
+                msg = self.receiver.recv(), if !self.is_rekeying() => {
+                    match msg {
+                        Some(Msg::Channel(id, ChannelMsg::Data { data })) => {
+                            self.data(id, data);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::ExtendedData { ext, data })) => {
+                            self.extended_data(id, ext, data);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::Eof)) => {
+                            self.eof(id);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::Close)) => {
+                            self.close(id);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::Success)) => {
+                            self.channel_success(id);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::XonXoff { client_can_do })) => {
+                            self.xon_xoff_request(id, client_can_do);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::ExitStatus { exit_status })) => {
+                            self.exit_status_request(id, exit_status);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::ExitSignal { signal_name, core_dumped, error_message, lang_tag })) => {
+                            self.exit_signal_request(id, signal_name, core_dumped, &error_message, &lang_tag);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::WindowAdjusted { new_size })) => {
+                            debug!("window adjusted to {:?} for channel {:?}", new_size, id);
+                        }
+                        Some(Msg::ChannelOpenSession { sender }) => {
+                            let id = self.channel_open_session()?;
+                            self.channels.insert(id, sender);
+                        }
+                        Some(Msg::ChannelOpenDirectTcpIp { host_to_connect, port_to_connect, originator_address, originator_port, sender }) => {
+                            let id = self.channel_open_direct_tcpip(&host_to_connect, port_to_connect, &originator_address, originator_port)?;
+                            self.channels.insert(id, sender);
+                        }
+                        Some(_) => {
+                            debug!("unimplemented (intended for client?) message: {:?}", msg);
+                            self.unimplemented(0);
+                        }
+                        None => {
+                            debug!("self.receiver: received None");
+                        }
+                    }
+                }
+            }
+            self.flush()?;
+            stream_write
+                .write_all(&self.common.write_buffer.buffer)
+                .await
+                .map_err(crate::Error::from)?;
+            self.common.write_buffer.buffer.clear();
+        }
+        debug!("disconnected");
+        // Shutdown
+        stream_write.shutdown().await.map_err(crate::Error::from)?;
+        loop {
+            if let Some((stream_read, buffer, opening_cipher)) = is_reading.take() {
+                reading.set(start_reading(stream_read, buffer, opening_cipher));
+            }
+            let (n, r, b, opening_cipher) = (&mut reading).await?;
+            is_reading = Some((r, b, opening_cipher));
+            if n == 0 {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Application-unqiue session ID. Can be used for identifying the session
+    /// across method calls.
+    pub fn id(&self) -> usize {
+        self.session_id
     }
 
     /// Get a handle to this session.
@@ -394,6 +663,89 @@ impl Session {
         }
     }
 
+    /// Opens a new session channel on the client.
+    pub fn channel_open_session(&mut self) -> Result<ChannelId, Error> {
+        let result = if let Some(ref mut enc) = self.common.encrypted {
+            if !matches!(
+                enc.state,
+                EncryptedState::Authenticated | EncryptedState::InitCompression
+            ) {
+                return Err(Error::Inconsistent);
+            }
+
+            let sender_channel = enc.new_channel(
+                self.common.config.window_size,
+                self.common.config.maximum_packet_size,
+            );
+            push_packet!(enc.write, {
+                enc.write.push(msg::CHANNEL_OPEN);
+                enc.write.extend_ssh_string(b"session");
+
+                // sender channel id.
+                enc.write.push_u32_be(sender_channel.0);
+
+                // window.
+                enc.write
+                    .push_u32_be(self.common.config.as_ref().window_size);
+
+                // max packet size.
+                enc.write
+                    .push_u32_be(self.common.config.as_ref().maximum_packet_size);
+            });
+            sender_channel
+        } else {
+            return Err(Error::Inconsistent);
+        };
+        Ok(result)
+    }
+
+    /// Opens a direct TCP/IP channel on the client.
+    pub fn channel_open_direct_tcpip(
+        &mut self,
+        host_to_connect: &str,
+        port_to_connect: u32,
+        originator_address: &str,
+        originator_port: u32,
+    ) -> Result<ChannelId, Error> {
+        let result = if let Some(ref mut enc) = self.common.encrypted {
+            if !matches!(
+                enc.state,
+                EncryptedState::Authenticated | EncryptedState::InitCompression
+            ) {
+                return Err(Error::Inconsistent);
+            }
+            let sender_channel = enc.new_channel(
+                self.common.config.window_size,
+                self.common.config.maximum_packet_size,
+            );
+            push_packet!(enc.write, {
+                enc.write.push(msg::CHANNEL_OPEN);
+                enc.write.extend_ssh_string(b"direct-tcpip");
+
+                // sender channel id.
+                enc.write.push_u32_be(sender_channel.0);
+
+                // window.
+                enc.write
+                    .push_u32_be(self.common.config.as_ref().window_size);
+
+                // max packet size.
+                enc.write
+                    .push_u32_be(self.common.config.as_ref().maximum_packet_size);
+
+                enc.write.extend_ssh_string(host_to_connect.as_bytes());
+                enc.write.push_u32_be(port_to_connect); // sender channel id.
+                enc.write.extend_ssh_string(originator_address.as_bytes());
+                enc.write.push_u32_be(originator_port); // sender channel id.
+            });
+            sender_channel
+        } else {
+            return Err(Error::Inconsistent);
+        };
+
+        Ok(result)
+    }
+
     /// Open a TCP/IP forwarding channel, when a connection comes to a
     /// local port for which forwarding has been requested. See
     /// [RFC4254](https://tools.ietf.org/html/rfc4254#section-7). The
@@ -407,38 +759,39 @@ impl Session {
         originator_port: u32,
     ) -> Result<ChannelId, Error> {
         let result = if let Some(ref mut enc) = self.common.encrypted {
-            match enc.state {
-                EncryptedState::Authenticated => {
-                    debug!("sending open request");
-
-                    let sender_channel = enc.new_channel(
-                        self.common.config.window_size,
-                        self.common.config.maximum_packet_size,
-                    );
-                    push_packet!(enc.write, {
-                        enc.write.push(msg::CHANNEL_OPEN);
-                        enc.write.extend_ssh_string(b"forwarded-tcpip");
-
-                        // sender channel id.
-                        enc.write.push_u32_be(sender_channel.0);
-
-                        // window.
-                        enc.write
-                            .push_u32_be(self.common.config.as_ref().window_size);
-
-                        // max packet size.
-                        enc.write
-                            .push_u32_be(self.common.config.as_ref().maximum_packet_size);
-
-                        enc.write.extend_ssh_string(connected_address.as_bytes());
-                        enc.write.push_u32_be(connected_port); // sender channel id.
-                        enc.write.extend_ssh_string(originator_address.as_bytes());
-                        enc.write.push_u32_be(originator_port); // sender channel id.
-                    });
-                    sender_channel
-                }
-                _ => return Err(Error::Inconsistent),
+            if !matches!(
+                enc.state,
+                EncryptedState::Authenticated | EncryptedState::InitCompression
+            ) {
+                return Err(Error::Inconsistent);
             }
+
+            debug!("sending open request");
+            let sender_channel = enc.new_channel(
+                self.common.config.window_size,
+                self.common.config.maximum_packet_size,
+            );
+            push_packet!(enc.write, {
+                enc.write.push(msg::CHANNEL_OPEN);
+                enc.write.extend_ssh_string(b"forwarded-tcpip");
+
+                // sender channel id.
+                enc.write.push_u32_be(sender_channel.0);
+
+                // window.
+                enc.write
+                    .push_u32_be(self.common.config.as_ref().window_size);
+
+                // max packet size.
+                enc.write
+                    .push_u32_be(self.common.config.as_ref().maximum_packet_size);
+
+                enc.write.extend_ssh_string(connected_address.as_bytes());
+                enc.write.push_u32_be(connected_port); // sender channel id.
+                enc.write.extend_ssh_string(originator_address.as_bytes());
+                enc.write.push_u32_be(originator_port); // sender channel id.
+            });
+            sender_channel
         } else {
             return Err(Error::Inconsistent);
         };

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -389,7 +389,7 @@ pub enum EncryptedState {
     Authenticated,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Exchange {
     pub client_id: CryptoVec,
     pub server_id: CryptoVec,

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -24,7 +24,7 @@ use russh_keys::encoding::Encoding;
 use crate::cipher::SealingKey;
 use crate::kex::KexAlgorithm;
 use crate::sshbuffer::SSHBuffer;
-use crate::{auth, cipher, mac, msg, negotiation, Channel, ChannelId, Disconnect, Limits};
+use crate::{auth, cipher, mac, msg, negotiation, ChannelId, ChannelParams, Disconnect, Limits};
 
 #[derive(Debug)]
 pub(crate) struct Encrypted {
@@ -38,7 +38,7 @@ pub(crate) struct Encrypted {
     pub server_mac: mac::Name,
     pub session_id: CryptoVec,
     pub rekey: Option<Kex>,
-    pub channels: HashMap<ChannelId, Channel>,
+    pub channels: HashMap<ChannelId, ChannelParams>,
     pub last_channel_id: Wrapping<u32>,
     pub write: CryptoVec,
     pub write_cursor: usize,
@@ -222,7 +222,7 @@ impl Encrypted {
     /// return the length that was written.
     fn data_noqueue(
         write: &mut CryptoVec,
-        channel: &mut Channel,
+        channel: &mut ChannelParams,
         buf0: &[u8],
         from: usize,
     ) -> usize {
@@ -329,10 +329,12 @@ impl Encrypted {
                 #[allow(clippy::indexing_slicing)] // length checked
                 let len = BigEndian::read_u32(&self.write[self.write_cursor..]) as usize;
                 #[allow(clippy::indexing_slicing)]
-                let packet = self.compress.compress(
-                    &self.write[(self.write_cursor + 4)..(self.write_cursor + 4 + len)],
-                    &mut self.compress_buffer,
-                )?;
+                let to_write = &self.write[(self.write_cursor + 4)..(self.write_cursor + 4 + len)];
+                trace!("server_write_encrypted, buf = {:?}", to_write);
+                #[allow(clippy::indexing_slicing)]
+                let packet = self
+                    .compress
+                    .compress(to_write, &mut self.compress_buffer)?;
                 cipher.write(packet, write_buffer);
                 self.write_cursor += 4 + len
             }
@@ -362,7 +364,7 @@ impl Encrypted {
             if let std::collections::hash_map::Entry::Vacant(vacant_entry) =
                 self.channels.entry(ChannelId(self.last_channel_id.0))
             {
-                vacant_entry.insert(Channel {
+                vacant_entry.insert(ChannelParams {
                     recipient_channel: 0,
                     sender_channel: ChannelId(self.last_channel_id.0),
                     sender_window_size: window_size,
@@ -535,4 +537,3 @@ pub struct NewKeys {
     pub received: bool,
     pub sent: bool,
 }
-


### PR DESCRIPTION
- Allow openssl to be vendored rather than dynamically linked for our builds
- Allow the server to initiate opening channels... I later realized that Basis actually doesn't do this (and instead uses `forward-tcpip`, not `direct-tcpip`) but I made the changes so figured I'd include them. This involved some refactoring to make the "Channel" more generic, though ultimately encoding and sending messages is still handled by the respective sessions.

    This also involved aligning the server `run_stream` to be async and return a handle like the client does, which I think is a good overall improvement.
- Aaaand actually add support for `tcpip-forward`, which is what Basis does.

I plan to slice up these commits and PR them upstream next week.