### PR TITLE
Disable bcrypt_pbkdf without rs-crypto

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,9 @@ jobs:
     - name: Build (no features enabled)
       run: cargo build --verbose
 
+    - name: Build (OpenSSL only)
+      run: cargo build --no-default-features --features openssl --verbose
+
     - name: Build (all features enabled)
       run: cargo build --verbose --all-features
 
@@ -30,6 +33,9 @@ jobs:
 
     - name: Clippy (no features enabled)
       run: cargo clippy -- -D warnings
+
+    - name: Clippy (OpenSSL only)
+      run: cargo clippy --no-default-features --features openssl -- -D warnings
 
     - name: Clippy (all features enabled)
       run: cargo clippy --all-features -- -D warnings
@@ -44,6 +50,13 @@ jobs:
       run: |
         eval `ssh-agent`
         cargo test --verbose
+      env:
+        RUST_BACKTRACE: 1
+
+    - name: Test (OpenSSL only)
+      run: |
+        eval `ssh-agent`
+        cargo test --verbose --no-default-features --features openssl
       env:
         RUST_BACKTRACE: 1
 

--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -30,7 +30,7 @@ version = "0.22.0-beta.7"
 
 [dependencies]
 aes = { version = "0.8", optional = true }
-bcrypt-pbkdf = "0.6"
+bcrypt-pbkdf = { version = "0.6", optional = true }
 bit-vec = "0.6"
 cbc = { version = "0.1", optional = true }
 ctr = { version = "0.9", optional = true }
@@ -69,6 +69,7 @@ default = ["rs-crypto"]
 vendored-openssl = ["openssl", "openssl/vendored"]
 rs-crypto = [
   "dep:aes",
+  "dep:bcrypt-pbkdf",
   "dep:cbc",
   "dep:ctr",
   "dep:block-padding",

--- a/russh-keys/src/agent/client.rs
+++ b/russh-keys/src/agent/client.rs
@@ -320,6 +320,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AgentClient<S> {
         key_blob(public, &mut self.buf)?;
         self.buf.extend_ssh_string(data);
         debug!("public = {:?}", public);
+        #[allow(unreachable_patterns)] // may not be unreachable depending on build flags
         let hash = match public {
             #[cfg(feature = "openssl")]
             PublicKey::RSA { hash, .. } => match hash {

--- a/russh-keys/src/format/openssh.rs
+++ b/russh-keys/src/format/openssh.rs
@@ -111,6 +111,7 @@ fn decrypt_secret_key(
             _ => return Err(Error::CouldNotReadKey),
         };
         match kdfname {
+            #[cfg(feature = "rs-crypto")]
             b"bcrypt" => {
                 let mut kdfopts = kdfoptions.reader(0);
                 let salt = kdfopts.read_string()?;

--- a/russh-keys/src/key.rs
+++ b/russh-keys/src/key.rs
@@ -236,6 +236,7 @@ impl PublicKey {
 
     #[cfg(feature = "openssl")]
     pub fn set_algorithm(&mut self, algorithm: &[u8]) {
+        #[allow(irrefutable_let_patterns)] // depending on the build flag, it may be refutable
         if let PublicKey::RSA { ref mut hash, .. } = self {
             if algorithm == b"rsa-sha2-512" {
                 *hash = SignatureHash::SHA2_512

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -856,6 +856,7 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
             let (_, buf) = client.sign_request(&public, buf).await;
             let _buf = buf?;
             #[cfg(feature = "rs-crypto")]
+            #[allow(irrefutable_let_patterns)]
             {
                 let (a, b) = _buf.split_at(_len);
                 if let key::KeyPair::Ed25519 { .. } = key {

--- a/russh/examples/echoserver.rs
+++ b/russh/examples/echoserver.rs
@@ -20,7 +20,7 @@ async fn main() {
     config.auth_rejection_time = std::time::Duration::from_secs(3);
     config
         .keys
-        .push(russh_keys::key::KeyPair::generate_ed25519().unwrap());
+        .push(russh_keys::key::KeyPair::generate_rsa(2048, key::SignatureHash::SHA1).unwrap());
     let config = Arc::new(config);
     let sh = Server {
         clients: Arc::new(Mutex::new(HashMap::new())),

--- a/russh/examples/echoserver.rs
+++ b/russh/examples/echoserver.rs
@@ -18,9 +18,16 @@ async fn main() {
     let mut config = russh::server::Config::default();
     config.connection_timeout = Some(std::time::Duration::from_secs(3600));
     config.auth_rejection_time = std::time::Duration::from_secs(3);
+
+    // Depending on whether you use OpenSSL or not, you can generate different keys:
+    #[cfg(feature = "openssl")]
+    let keypair = russh_keys::key::KeyPair::generate_rsa(2048, key::SignatureHash::SHA1).unwrap();
+    #[cfg(not(feature = "openssl"))]
+    let keypair = russh_keys::key::KeyPair::generate_ed25519().unwrap();
+
     config
         .keys
-        .push(russh_keys::key::KeyPair::generate_rsa(2048, key::SignatureHash::SHA1).unwrap());
+        .push(keypair);
     let config = Arc::new(config);
     let sh = Server {
         clients: Arc::new(Mutex::new(HashMap::new())),


### PR DESCRIPTION
This breaks the loading of private keys, but we don't use them for VS Code's use case. It drops the dependency on `blowfish`, which is flagged as a problematic dependency. 

OpenSSL does implement blowfish encryption, but it doesn't have key expansion which is necessary to implement bcrypt_pbkdf. So just disable it.