### PR TITLE
Fix CVE-2024-43410: OOM DoS via untrusted packet length

### DIFF
--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -225,7 +225,13 @@ pub(crate) async fn read<'a, R: AsyncRead + Unpin>(
             buffer.buffer.extend(&len);
             debug!("reading, seqn = {:?}", seqn);
             let len = cipher.decrypt_packet_length(seqn, len)?;
-            buffer.len = BigEndian::read_u32(&len) as usize + cipher.tag_len();
+            let len = BigEndian::read_u32(&len) as usize;
+
+            if len > MAXIMUM_PACKET_LEN {
+                return Err(Error::PacketSize(len));
+            }
+
+            buffer.len = len + cipher.tag_len();
             debug!("reading, clear len = {:?}", buffer.len);
         }
     }
@@ -261,5 +267,6 @@ pub(crate) async fn read<'a, R: AsyncRead + Unpin>(
 pub(crate) const PACKET_LENGTH_LEN: usize = 4;
 
 const MINIMUM_PACKET_LEN: usize = 16;
+const MAXIMUM_PACKET_LEN: usize = 256 * 1024;
 
 const PADDING_LENGTH_LEN: usize = 1;

--- a/russh/src/lib.rs
+++ b/russh/src/lib.rs
@@ -219,6 +219,10 @@ pub enum Error {
     #[error("Wrong server signature")]
     WrongServerSig,
 
+    /// Excessive packet size.
+    #[error("Bad packet size: {0}")]
+    PacketSize(usize),
+
     /// Message received/sent on unopened channel.
     #[error("Channel not open")]
     WrongChannel,


### PR DESCRIPTION
## Summary

Cherry-picks the fix for [CVE-2024-43410](https://nvd.nist.gov/vuln/detail/CVE-2024-43410) (GHSA-vgvv-x7xg-6cqg) from upstream [Eugeny/russh@f660ea3](https://github.com/Eugeny/russh/commit/f660ea3) onto the current 0.37.1 base.

**Vulnerability:** After decrypting the 4-byte packet length, russh allocates memory for the entire declared size without validation. A malicious SSH peer can set an arbitrarily large length, causing the process to OOM within a few requests.

**Fix:** Adds a `MAXIMUM_PACKET_LEN` constant (256 KiB) and validates the decrypted length before allocation, returning a new `Error::PacketSize` if exceeded.

## Changes

- `russh/src/cipher/mod.rs` — Add max length constant and validation check before buffer allocation
- `russh/src/lib.rs` — Add `PacketSize(usize)` error variant

The only merge conflict was in `decrypt_packet_length` call signature (this fork uses `Result` return type with `?`), resolved by keeping the fork's signature while adding the upstream length validation.

## References

- [CVE-2024-43410 (NVD)](https://nvd.nist.gov/vuln/detail/CVE-2024-43410)
- [GHSA-vgvv-x7xg-6cqg](https://github.com/Eugeny/russh/security/advisories/GHSA-vgvv-x7xg-6cqg)
- [Upstream fix commit](https://github.com/Eugeny/russh/commit/f660ea3)
- Fixed in upstream russh 0.44.1